### PR TITLE
Create server subdirectory by default

### DIFF
--- a/shellmcp/cli.py
+++ b/shellmcp/cli.py
@@ -106,10 +106,15 @@ def generate(config_file: str, output_dir: str = None, verbose: bool = False) ->
         
         # Determine output directory
         if output_dir is None:
-            output_dir = Path(config_file).parent
+            # Create a subdirectory matching the server name by default
+            config_dir = Path(config_file).parent
+            server_name = config.server.name.replace('-', '_').replace(' ', '_').lower()
+            output_dir = config_dir / server_name
         else:
             output_dir = Path(output_dir)
-            output_dir.mkdir(parents=True, exist_ok=True)
+        
+        # Create the output directory
+        output_dir.mkdir(parents=True, exist_ok=True)
         
         # Generate server file
         server_file = generator.generate_server(config_file, str(output_dir / f"{config.server.name.replace('-', '_')}_server.py"))

--- a/shellmcp/generator.py
+++ b/shellmcp/generator.py
@@ -48,6 +48,10 @@ class FastMCPGenerator:
             config_path = Path(config_file)
             output_file = config_path.parent / f"{config.server.name.replace('-', '_')}_server.py"
         
+        # Ensure the output directory exists
+        output_path = Path(output_file)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        
         # Write server file
         with open(output_file, 'w', encoding='utf-8') as f:
             f.write(server_code)
@@ -68,6 +72,10 @@ class FastMCPGenerator:
         if output_file is None:
             output_file = "requirements.txt"
         
+        # Ensure the output directory exists
+        output_path = Path(output_file)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        
         with open(output_file, 'w', encoding='utf-8') as f:
             f.write(requirements)
         
@@ -80,6 +88,10 @@ class FastMCPGenerator:
         
         if output_file is None:
             output_file = "README.md"
+        
+        # Ensure the output directory exists
+        output_path = Path(output_file)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
         
         with open(output_file, 'w', encoding='utf-8') as f:
             f.write(readme_content)


### PR DESCRIPTION
Create a subdirectory matching the server name by default when generating a server to improve output organization.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c2f1086-168e-40eb-a88c-f467da667330">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2c2f1086-168e-40eb-a88c-f467da667330">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

