### PR TITLE
Change default output to mcp subdirectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,13 @@ shellmcp validate my-server.yml --verbose
 ### `shellmcp generate`
 Generate a FastMCP server from YAML configuration.
 
+**Default behavior**: Creates a subdirectory with the server name to prevent overwriting existing files.
+
 ```bash
+# Generate with default output directory (creates ./my-server/ subdirectory)
+shellmcp generate my-server.yml --verbose
+
+# Generate with custom output directory
 shellmcp generate my-server.yml --output-dir ./output --verbose
 ```
 

--- a/docs/agentdocs/cli/README.md
+++ b/docs/agentdocs/cli/README.md
@@ -42,7 +42,53 @@ shellmcp validate config.yml
 shellmcp validate config.yml --verbose
 ```
 
-**Output:**
+### `generate`
+
+Generate a FastMCP server from YAML configuration.
+
+```bash
+shellmcp generate <config_file> [--output-dir <dir>] [--verbose]
+```
+
+**Arguments:**
+- `config_file`: Path to the YAML configuration file
+
+**Flags:**
+- `--output-dir`: Optional output directory (defaults to creating a subdirectory with the server name)
+- `--verbose` / `-v`: Show detailed generation information
+
+**Default Behavior:**
+When no `--output-dir` is specified, the generator automatically creates a subdirectory named after the server (with spaces and hyphens converted to underscores). This prevents accidentally overwriting existing files like README.md in your current directory.
+
+**Examples:**
+
+```bash
+# Generate with default output directory (creates ./my-server/ subdirectory)
+shellmcp generate my-server.yml --verbose
+
+# Generate with custom output directory
+shellmcp generate my-server.yml --output-dir ./output --verbose
+```
+
+**Generate Output:**
+
+The `generate` command creates a complete FastMCP server with the following files:
+
+```
+✅ FastMCP server generated successfully!
+📁 Output directory: /path/to/my_mcp_server
+🐍 Server file: /path/to/my_mcp_server/my_mcp_server_server.py
+📦 Requirements: /path/to/my_mcp_server/requirements.txt
+📖 Documentation: /path/to/my_mcp_server/README.md
+
+🚀 To run the server:
+   cd /path/to/my_mcp_server
+   python3 -m venv venv && source venv/bin/activate
+   pip install -r requirements.txt
+   python my_mcp_server_server.py
+```
+
+**Validation Output:**
 
 The `validate` command performs comprehensive validation including:
 

--- a/docs/agentdocs/generator/README.md
+++ b/docs/agentdocs/generator/README.md
@@ -26,12 +26,21 @@ The generator takes a YAML configuration file and produces:
 ### Command Line Interface
 
 ```bash
-# Generate server from YAML configuration
+# Generate server from YAML configuration (creates ./server-name/ subdirectory by default)
 python -m shellmcp.cli generate config.yml --verbose
 
 # Generate with custom output directory
 python -m shellmcp.cli generate config.yml --output-dir ./output --verbose
 ```
+
+**Default Output Directory Behavior**
+
+When no `--output-dir` is specified, the generator automatically creates a subdirectory named after the server (with spaces and hyphens converted to underscores). This prevents accidentally overwriting existing files like README.md in your current directory.
+
+For example, if your server is named "my-mcp-server", the generator will create a `my_mcp_server/` directory containing:
+- `my_mcp_server_server.py` - The generated server
+- `requirements.txt` - Python dependencies
+- `README.md` - Documentation
 
 ### Programmatic Usage
 

--- a/shellmcp/cli.py
+++ b/shellmcp/cli.py
@@ -93,7 +93,7 @@ def generate(config_file: str, output_dir: str = None, verbose: bool = False) ->
     
     Args:
         config_file: Path to the YAML configuration file
-        output_dir: Optional output directory (defaults to same directory as config file)
+        output_dir: Optional output directory (defaults to creating a subdirectory with the server name)
         verbose: Show detailed generation information
     
     Returns:
@@ -116,6 +116,8 @@ def generate(config_file: str, output_dir: str = None, verbose: bool = False) ->
         
         # Determine output directory
         if output_dir is None:
+            # Default behavior: create a subdirectory with the server name
+            # This prevents accidentally overwriting existing files like README.md
             config_dir = Path(config_file).parent
             server_name = config.server.name.replace('-', '_').replace(' ', '_').lower()
             output_dir = config_dir / server_name


### PR DESCRIPTION
Clarify default output directory behavior in documentation and CLI help to prevent users from accidentally overwriting files.

The `shellmcp generate` command already creates a subdirectory named after the server by default. This PR updates the README, CLI documentation, generator documentation, and code comments to explicitly state this behavior, addressing user confusion about files being overwritten in the current directory.

---
<a href="https://cursor.com/background-agent?bcId=bc-ae102d96-812d-439f-8a79-459603a5cd6f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ae102d96-812d-439f-8a79-459603a5cd6f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

