### PR TITLE
Create optional mcp server from yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,10 @@ Define your tools in YAML, and ShellMCP generates a complete FastMCP server for 
 # Install ShellMCP
 pip install shellmcp
 
-# Create a new server configuration
+# Run a built-in MCP server directly
+shellmcp run basics
+
+# Or create a custom server configuration
 shellmcp new --name "my-server" --desc "My custom MCP server"
 
 # Add a tool interactively
@@ -23,6 +26,9 @@ shellmcp validate my-server.yml
 
 # Generate the FastMCP server
 shellmcp generate my-server.yml
+
+# Or run directly from a YAML file
+shellmcp run --config_file my-server.yml
 ```
 
 ## Features
@@ -102,6 +108,29 @@ prompts:
 ## CLI Commands
 
 ShellMCP provides several commands to help you create and manage MCP servers:
+
+### `shellmcp run`
+Run an MCP server directly from a built-in configuration or YAML file.
+
+```bash
+# Run a built-in configuration
+shellmcp run basics
+
+# Run from a custom YAML file
+shellmcp run --config_file my-server.yml
+```
+
+Built-in configurations:
+- **basics**: Basic shell operations for file system, process management, and system information
+
+The `basics` configuration includes tools for:
+- File operations (list, find, copy, move, delete)
+- Directory management (create, remove, navigate)
+- Process management (list, kill processes)
+- System information (memory, disk, network)
+- Text operations (read, write, search)
+- Resources for system status and environment info
+- Prompts for file analysis and system diagnosis
 
 ### `shellmcp new`
 Create a new server configuration file.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "jinja2>=3.0.0",
     "fire>=0.5.0",
     "questionary>=2.0.0",
+    "fastmcp>=0.1.0",
 ]
 
 [project.optional-dependencies]
@@ -30,7 +31,7 @@ where = ["."]
 include = ["shellmcp*"]
 
 [tool.setuptools.package-data]
-shellmcp = ["templates/*.j2"]
+shellmcp = ["templates/*.j2", "configs/*.yml"]
 
 [project.scripts]
 shellmcp = "shellmcp.cli:main"

--- a/shellmcp/cli.py
+++ b/shellmcp/cli.py
@@ -17,6 +17,7 @@ from .models import (
     YMLConfig,
 )
 from .parser import YMLParser
+from .runner import run_config, get_builtin_config
 from .utils import get_choice, get_input, get_yes_no, load_or_create_config, save_config
 
 
@@ -538,6 +539,49 @@ def add_prompt(config_file: str, name: str = None, prompt_name: str = None, desc
         return _handle_error(f"Error adding prompt: {e}", exception=e)
 
 
+def run(config_name: str = None, config_file: str = None) -> int:
+    """
+    Run an MCP server from a built-in configuration or YAML file.
+    
+    Args:
+        config_name: Name of built-in configuration (e.g., 'basics')
+        config_file: Path to YAML configuration file
+    
+    Returns:
+        Exit code (0 for success, 1 for failure)
+    """
+    try:
+        if config_name and config_file:
+            return _handle_error("Cannot specify both config_name and config_file. Use one or the other.")
+        
+        if not config_name and not config_file:
+            return _handle_error("Must specify either config_name (for built-in configs) or config_file (for custom configs)")
+        
+        # Determine which config to use
+        if config_name:
+            # Use built-in configuration
+            try:
+                config_path = get_builtin_config(config_name)
+                print(f"🚀 Starting built-in MCP server: {config_name}")
+                print(f"📁 Configuration: {config_path}")
+            except ValueError as e:
+                return _handle_error(str(e))
+        else:
+            # Use custom configuration file
+            if not _check_file_exists(config_file):
+                return _handle_error(f"Configuration file '{config_file}' not found")
+            
+            config_path = config_file
+            print(f"🚀 Starting MCP server from configuration: {config_file}")
+        
+        # Run the server
+        run_config(config_path)
+        return 0
+        
+    except Exception as e:
+        return _handle_error(f"Error running MCP server: {e}", exception=e)
+
+
 def main():
     """Main CLI entry point using Fire."""
     fire.Fire({
@@ -546,5 +590,6 @@ def main():
         'new': new,
         'add-tool': add_tool,
         'add-resource': add_resource,
-        'add-prompt': add_prompt
+        'add-prompt': add_prompt,
+        'run': run
     })

--- a/shellmcp/configs/__init__.py
+++ b/shellmcp/configs/__init__.py
@@ -1,0 +1,1 @@
+"""Pre-configured MCP server configurations."""

--- a/shellmcp/configs/basics.yml
+++ b/shellmcp/configs/basics.yml
@@ -1,0 +1,273 @@
+server:
+  name: "basics"
+  desc: "Basic shell operations for file system, process management, and system information"
+  version: "1.0.0"
+
+tools:
+  list_files:
+    cmd: "{% if recursive %}find {{ path }} -type f{% else %}ls -la {{ path }}{% endif %}"
+    desc: "List files and directories"
+    args:
+      - name: path
+        help: "Directory or file path"
+        type: string
+        default: "."
+      - name: recursive
+        help: "Include subdirectories recursively"
+        type: boolean
+        default: false
+
+  find_files:
+    cmd: "find {{ path }} -name '{{ pattern }}' -type f"
+    desc: "Find files matching a pattern"
+    args:
+      - name: path
+        help: "Directory or file path"
+        type: string
+        default: "."
+      - name: pattern
+        help: "Search pattern (supports glob patterns)"
+        type: string
+
+  file_info:
+    cmd: "file {{ path }}"
+    desc: "Get detailed file information"
+    args:
+      - name: path
+        help: "Directory or file path"
+        type: string
+        default: "."
+
+  file_size:
+    cmd: "du -h {{ path }}"
+    desc: "Get file or directory size"
+    args:
+      - name: path
+        help: "Directory or file path"
+        type: string
+        default: "."
+
+  create_directory:
+    cmd: "mkdir -p {{ path }}"
+    desc: "Create a directory (including parent directories)"
+    args:
+      - name: path
+        help: "Directory path to create"
+        type: string
+
+  remove_file:
+    cmd: "rm {{ path }}"
+    desc: "Remove a file"
+    args:
+      - name: path
+        help: "Directory or file path"
+        type: string
+        default: "."
+
+  remove_directory:
+    cmd: "rm -rf {{ path }}"
+    desc: "Remove a directory and its contents"
+    args:
+      - name: path
+        help: "Directory or file path"
+        type: string
+        default: "."
+
+  copy_file:
+    cmd: "cp {{ source }} {{ destination }}"
+    desc: "Copy a file"
+    args:
+      - name: source
+        help: "Source file path"
+        type: string
+      - name: destination
+        help: "Destination file path"
+        type: string
+
+  move_file:
+    cmd: "mv {{ source }} {{ destination }}"
+    desc: "Move or rename a file"
+    args:
+      - name: source
+        help: "Source file path"
+        type: string
+      - name: destination
+        help: "Destination file path"
+        type: string
+
+  read_file:
+    cmd: "cat {{ path }}"
+    desc: "Read file contents"
+    args:
+      - name: path
+        help: "Directory or file path"
+        type: string
+        default: "."
+
+  write_file:
+    cmd: "echo '{{ content }}' > {{ path }}"
+    desc: "Write content to a file"
+    args:
+      - name: path
+        help: "Directory or file path"
+        type: string
+        default: "."
+      - name: content
+        help: "Content to write to the file"
+        type: string
+
+  append_file:
+    cmd: "echo '{{ content }}' >> {{ path }}"
+    desc: "Append content to a file"
+    args:
+      - name: path
+        help: "Directory or file path"
+        type: string
+        default: "."
+      - name: content
+        help: "Content to append to the file"
+        type: string
+
+  grep_text:
+    cmd: "grep -r '{{ pattern }}' {{ path }}"
+    desc: "Search for text in files"
+    args:
+      - name: pattern
+        help: "Text pattern to search for"
+        type: string
+      - name: path
+        help: "Directory or file path"
+        type: string
+        default: "."
+
+  process_list:
+    cmd: "ps aux | head -{{ count }}"
+    desc: "List running processes"
+    args:
+      - name: count
+        help: "Number of items to show"
+        type: number
+        default: 10
+
+  process_kill:
+    cmd: "kill {{ pid }}"
+    desc: "Kill a process by PID"
+    args:
+      - name: pid
+        help: "Process ID to kill"
+        type: number
+
+  system_info:
+    cmd: "uname -a && uptime && df -h"
+    desc: "Get system information (OS, uptime, disk usage)"
+
+  memory_info:
+    cmd: "free -h"
+    desc: "Get memory usage information"
+
+  network_info:
+    cmd: "ifconfig || ip addr show"
+    desc: "Get network interface information"
+
+  current_directory:
+    cmd: "pwd"
+    desc: "Get current working directory"
+
+  change_directory:
+    cmd: "cd {{ path }} && pwd"
+    desc: "Change to a directory and show the new path"
+    args:
+      - name: path
+        help: "Directory or file path"
+        type: string
+        default: "."
+
+  environment_vars:
+    cmd: "env | sort"
+    desc: "List all environment variables"
+
+  command_history:
+    cmd: "history | tail -{{ count }}"
+    desc: "Show recent command history"
+    args:
+      - name: count
+        help: "Number of items to show"
+        type: number
+        default: 10
+
+resources:
+  system_status:
+    uri: "system://status"
+    name: "System Status"
+    description: "Current system status and information"
+    mime_type: "text/plain"
+    cmd: "uname -a && echo '---' && uptime && echo '---' && df -h && echo '---' && free -h"
+
+  current_directory_contents:
+    uri: "file://current-directory"
+    name: "Current Directory Contents"
+    description: "Contents of the current working directory"
+    mime_type: "text/plain"
+    cmd: "pwd && echo '---' && ls -la"
+
+  environment:
+    uri: "env://variables"
+    name: "Environment Variables"
+    description: "Current environment variables"
+    mime_type: "text/plain"
+    cmd: "env | sort"
+
+prompts:
+  file_analysis:
+    name: "File System Analysis"
+    description: "Analyze file system structure and provide insights"
+    template: |
+      You are a file system analysis expert. Please analyze the following file system information:
+      
+      Current directory: {{ current_dir }}
+      Directory contents:
+      {{ directory_contents }}
+      
+      Please provide insights about:
+      1. File organization and structure
+      2. Potential issues or improvements
+      3. Recommendations for better organization
+      4. Security considerations (if any)
+      
+      Be specific and actionable in your recommendations.
+    args:
+      - name: current_dir
+        help: "Current directory path"
+        type: string
+        default: "."
+      - name: directory_contents
+        help: "Contents of the directory to analyze"
+        type: string
+
+  system_diagnosis:
+    name: "System Diagnosis"
+    description: "Diagnose system health and performance"
+    template: |
+      You are a system administrator. Please analyze the following system information:
+      
+      System Info: {{ system_info }}
+      Memory Usage: {{ memory_info }}
+      Disk Usage: {{ disk_info }}
+      
+      Please provide:
+      1. Overall system health assessment
+      2. Potential performance issues
+      3. Recommendations for optimization
+      4. Any immediate concerns that need attention
+      
+      Focus on actionable insights and prioritize by urgency.
+    args:
+      - name: system_info
+        help: "System information (uname, uptime)"
+        type: string
+      - name: memory_info
+        help: "Memory usage information"
+        type: string
+      - name: disk_info
+        help: "Disk usage information"
+        type: string

--- a/shellmcp/runner.py
+++ b/shellmcp/runner.py
@@ -1,0 +1,555 @@
+"""Direct MCP server runner from YAML configuration."""
+
+import os
+import subprocess
+import tempfile
+import shlex
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from fastmcp import FastMCP
+from jinja2 import Template, Environment
+
+from .models import YMLConfig
+from .parser import YMLParser
+
+
+def execute_command(cmd: str, env_vars: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
+    """Execute a shell command and return the result."""
+    try:
+        # Prepare environment
+        env = os.environ.copy()
+        if env_vars:
+            env.update(env_vars)
+        
+        # Execute command
+        result = subprocess.run(
+            cmd,
+            shell=True,
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=300  # 5 minute timeout
+        )
+        
+        return {
+            "success": result.returncode == 0,
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+            "returncode": result.returncode
+        }
+    except subprocess.TimeoutExpired:
+        return {
+            "success": False,
+            "stdout": "",
+            "stderr": "Command timed out after 5 minutes",
+            "returncode": -1
+        }
+    except Exception as e:
+        return {
+            "success": False,
+            "stdout": "",
+            "stderr": str(e),
+            "returncode": -1
+        }
+
+
+def render_template(template_str: str, **kwargs) -> str:
+    """Render Jinja2 template with provided variables."""
+    try:
+        # Add built-in functions
+        context = {
+            'now': datetime.now,
+            **kwargs
+        }
+        
+        template = Template(template_str)
+        return template.render(**context)
+    except Exception as e:
+        raise ValueError(f"Template rendering error: {e}")
+
+
+class MCPRunner:
+    """Direct MCP server runner from YAML configuration."""
+    
+    def __init__(self, config: YMLConfig):
+        self.config = config
+        self.mcp = FastMCP(name=config.server.name)
+        self._setup_server()
+        self._register_tools()
+        self._register_resources()
+        self._register_prompts()
+    
+    def _setup_server(self):
+        """Set up server configuration and environment variables."""
+        # Set server environment variables
+        if self.config.server.env:
+            for key, value in self.config.server.env.items():
+                os.environ[key] = value
+    
+    def _register_tools(self):
+        """Register all tools from the configuration."""
+        if not self.config.tools:
+            return
+        
+        for tool_name, tool in self.config.tools.items():
+            self._register_tool(tool_name, tool)
+    
+    def _register_tool(self, tool_name: str, tool):
+        """Register a single tool."""
+        func_name = tool_name.lower().replace('-', '_')
+        resolved_args = self.config.get_resolved_arguments(tool_name)
+        
+        # Build function signature
+        params_with_defaults = []
+        params_without_defaults = []
+        
+        for arg in resolved_args:
+            if arg.default is not None:
+                param = f"{arg.name}: {self._python_type(arg.type)} = {self._python_value(arg.default, arg.type)}"
+                params_with_defaults.append(param)
+            else:
+                param = f"{arg.name}: {self._python_type(arg.type)}"
+                params_without_defaults.append(param)
+        
+        param_str = ", ".join(params_without_defaults + params_with_defaults)
+        
+        # Create the tool function with explicit parameters
+        def create_tool_func(tool_name, tool, resolved_args):
+            # Build the function signature dynamically
+            if not resolved_args:
+                def tool_func() -> Dict[str, Any]:
+                    try:
+                        # Render command template
+                        cmd = render_template(tool.cmd)
+                        
+                        # Execute command
+                        env_vars = {}
+                        if tool.env:
+                            env_vars.update(tool.env)
+                        
+                        result = execute_command(cmd, env_vars)
+                        return result
+                        
+                    except Exception as e:
+                        return {
+                            "success": False,
+                            "stdout": "",
+                            "stderr": f"Error in {tool_name}: {str(e)}",
+                            "returncode": -1
+                        }
+            else:
+                # Create function with explicit parameters
+                import types
+                
+                # Build parameter list
+                param_names = []
+                param_defaults = []
+                
+                for arg in resolved_args:
+                    param_names.append(arg.name)
+                    if arg.default is not None:
+                        param_defaults.append(arg.default)
+                
+                # Create function code
+                func_code = f"""
+def {func_name}({', '.join(param_names)}) -> Dict[str, Any]:
+    try:
+        # Validate arguments
+        args_dict = {{{', '.join([f"'{name}': {name}" for name in param_names])}}}
+        
+        # Validate each argument
+        for arg_name, value in args_dict.items():
+            if value is None:
+                raise ValueError(f"Required argument '{{arg_name}}' not provided")
+        
+        # Render command template
+        cmd = render_template(tool.cmd, **args_dict)
+        
+        # Execute command
+        env_vars = {{}}
+        if tool.env:
+            env_vars.update(tool.env)
+        
+        result = execute_command(cmd, env_vars)
+        return result
+        
+    except Exception as e:
+        return {{
+            "success": False,
+            "stdout": "",
+            "stderr": f"Error in {tool_name}: {{str(e)}}",
+            "returncode": -1
+        }}
+"""
+                
+                # Execute the function code
+                func_globals = {
+                    'render_template': render_template,
+                    'execute_command': execute_command,
+                    'tool': tool,
+                    'tool_name': tool_name,
+                    'Dict': Dict,
+                    'Any': Any
+                }
+                func_locals = {}
+                exec(func_code, func_globals, func_locals)
+                tool_func = func_locals[func_name]
+            
+            # Set function metadata
+            tool_func.__name__ = func_name
+            tool_func.__doc__ = self._create_tool_docstring(tool_name, tool, resolved_args)
+            return tool_func
+        
+        # Register the tool
+        tool_func = create_tool_func(tool_name, tool, resolved_args)
+        self.mcp.tool()(tool_func)
+    
+    def _register_resources(self):
+        """Register all resources from the configuration."""
+        if not self.config.resources:
+            return
+        
+        for resource_name, resource in self.config.resources.items():
+            self._register_resource(resource_name, resource)
+    
+    def _register_resource(self, resource_name: str, resource):
+        """Register a single resource."""
+        func_name = resource_name.lower().replace('-', '_')
+        resolved_args = self.config.get_resolved_resource_arguments(resource_name)
+        
+        # Build function signature
+        params_with_defaults = []
+        params_without_defaults = []
+        
+        for arg in resolved_args:
+            if arg.default is not None:
+                param = f"{arg.name}: {self._python_type(arg.type)} = {self._python_value(arg.default, arg.type)}"
+                params_with_defaults.append(param)
+            else:
+                param = f"{arg.name}: {self._python_type(arg.type)}"
+                params_without_defaults.append(param)
+        
+        param_str = ", ".join(params_without_defaults + params_with_defaults)
+        
+        # Create the resource function with explicit parameters
+        def create_resource_func(resource_name, resource, resolved_args):
+            if not resolved_args:
+                def resource_func() -> str:
+                    try:
+                        # Get content based on source type
+                        if resource.text:
+                            content = render_template(resource.text)
+                        elif resource.file:
+                            file_path = render_template(resource.file)
+                            try:
+                                with open(file_path, 'r', encoding='utf-8') as f:
+                                    content = f.read()
+                            except FileNotFoundError:
+                                raise ValueError(f"Resource file not found: {file_path}")
+                            except Exception as e:
+                                raise ValueError(f"Error reading resource file {file_path}: {str(e)}")
+                        else:  # cmd
+                            cmd = render_template(resource.cmd)
+                            env_vars = {}
+                            if resource.env:
+                                env_vars.update(resource.env)
+                            
+                            result = execute_command(cmd, env_vars)
+                            if not result["success"]:
+                                raise ValueError(f"Command failed: {result['stderr']}")
+                            content = result["stdout"]
+                        
+                        return content
+                        
+                    except Exception as e:
+                        raise ValueError(f"Error in {resource_name}: {str(e)}")
+            else:
+                # Create function with explicit parameters
+                param_names = [arg.name for arg in resolved_args]
+                
+                func_code = f"""
+def {func_name}({', '.join(param_names)}) -> str:
+    try:
+        # Validate arguments
+        args_dict = {{{', '.join([f"'{name}': {name}" for name in param_names])}}}
+        
+        # Get content based on source type
+        if resource.text:
+            content = render_template(resource.text, **args_dict)
+        elif resource.file:
+            file_path = render_template(resource.file, **args_dict)
+            try:
+                with open(file_path, 'r', encoding='utf-8') as f:
+                    content = f.read()
+            except FileNotFoundError:
+                raise ValueError(f"Resource file not found: {{file_path}}")
+            except Exception as e:
+                raise ValueError(f"Error reading resource file {{file_path}}: {{str(e)}}")
+        else:  # cmd
+            cmd = render_template(resource.cmd, **args_dict)
+            env_vars = {{}}
+            if resource.env:
+                env_vars.update(resource.env)
+            
+            result = execute_command(cmd, env_vars)
+            if not result["success"]:
+                raise ValueError(f"Command failed: {{result['stderr']}}")
+            content = result["stdout"]
+        
+        return content
+        
+    except Exception as e:
+        raise ValueError(f"Error in {resource_name}: {{str(e)}}")
+"""
+                
+                # Execute the function code
+                func_globals = {
+                    'render_template': render_template,
+                    'execute_command': execute_command,
+                    'resource': resource,
+                    'resource_name': resource_name
+                }
+                func_locals = {}
+                exec(func_code, func_globals, func_locals)
+                resource_func = func_locals[func_name]
+            
+            # Set function metadata
+            resource_func.__name__ = func_name
+            resource_func.__doc__ = self._create_resource_docstring(resource_name, resource, resolved_args)
+            return resource_func
+        
+        # Register the resource
+        resource_func = create_resource_func(resource_name, resource, resolved_args)
+        # Convert Jinja2 template variables in URI to Python format
+        uri = resource.uri.replace('{{ ', '{').replace(' }}', '}').replace('{{', '{').replace('}}', '}')
+        self.mcp.resource(uri)(resource_func)
+    
+    def _register_prompts(self):
+        """Register all prompts from the configuration."""
+        if not self.config.prompts:
+            return
+        
+        for prompt_name, prompt in self.config.prompts.items():
+            self._register_prompt(prompt_name, prompt)
+    
+    def _register_prompt(self, prompt_name: str, prompt):
+        """Register a single prompt."""
+        func_name = prompt_name.lower().replace('-', '_')
+        resolved_args = self.config.get_resolved_prompt_arguments(prompt_name)
+        
+        # Build function signature
+        params_with_defaults = []
+        params_without_defaults = []
+        
+        for arg in resolved_args:
+            if arg.default is not None:
+                param = f"{arg.name}: {self._python_type(arg.type)} = {self._python_value(arg.default, arg.type)}"
+                params_with_defaults.append(param)
+            else:
+                param = f"{arg.name}: {self._python_type(arg.type)}"
+                params_without_defaults.append(param)
+        
+        param_str = ", ".join(params_without_defaults + params_with_defaults)
+        
+        # Create the prompt function with explicit parameters
+        def create_prompt_func(prompt_name, prompt, resolved_args):
+            if not resolved_args:
+                def prompt_func() -> str:
+                    try:
+                        # Get content based on source type
+                        if prompt.template:
+                            content = render_template(prompt.template)
+                        elif prompt.file:
+                            file_path = render_template(prompt.file)
+                            try:
+                                with open(file_path, 'r', encoding='utf-8') as f:
+                                    content = f.read()
+                            except FileNotFoundError:
+                                raise ValueError(f"Prompt file not found: {file_path}")
+                            except Exception as e:
+                                raise ValueError(f"Error reading prompt file {file_path}: {str(e)}")
+                        else:  # cmd
+                            cmd = render_template(prompt.cmd)
+                            env_vars = {}
+                            if prompt.env:
+                                env_vars.update(prompt.env)
+                            
+                            result = execute_command(cmd, env_vars)
+                            if not result["success"]:
+                                raise ValueError(f"Command failed: {result['stderr']}")
+                            content = result["stdout"]
+                        
+                        return content
+                        
+                    except Exception as e:
+                        raise ValueError(f"Error in {prompt_name}: {str(e)}")
+            else:
+                # Create function with explicit parameters
+                param_names = [arg.name for arg in resolved_args]
+                
+                func_code = f"""
+def {func_name}({', '.join(param_names)}) -> str:
+    try:
+        # Validate arguments
+        args_dict = {{{', '.join([f"'{name}': {name}" for name in param_names])}}}
+        
+        # Get content based on source type
+        if prompt.template:
+            content = render_template(prompt.template, **args_dict)
+        elif prompt.file:
+            file_path = render_template(prompt.file, **args_dict)
+            try:
+                with open(file_path, 'r', encoding='utf-8') as f:
+                    content = f.read()
+            except FileNotFoundError:
+                raise ValueError(f"Prompt file not found: {{file_path}}")
+            except Exception as e:
+                raise ValueError(f"Error reading prompt file {{file_path}}: {{str(e)}}")
+        else:  # cmd
+            cmd = render_template(prompt.cmd, **args_dict)
+            env_vars = {{}}
+            if prompt.env:
+                env_vars.update(prompt.env)
+            
+            result = execute_command(cmd, env_vars)
+            if not result["success"]:
+                raise ValueError(f"Command failed: {{result['stderr']}}")
+            content = result["stdout"]
+        
+        return content
+        
+    except Exception as e:
+        raise ValueError(f"Error in {prompt_name}: {{str(e)}}")
+"""
+                
+                # Execute the function code
+                func_globals = {
+                    'render_template': render_template,
+                    'execute_command': execute_command,
+                    'prompt': prompt,
+                    'prompt_name': prompt_name
+                }
+                func_locals = {}
+                exec(func_code, func_globals, func_locals)
+                prompt_func = func_locals[func_name]
+            
+            # Set function metadata
+            prompt_func.__name__ = func_name
+            prompt_func.__doc__ = self._create_prompt_docstring(prompt_name, prompt, resolved_args)
+            return prompt_func
+        
+        # Register the prompt
+        prompt_func = create_prompt_func(prompt_name, prompt, resolved_args)
+        self.mcp.prompt()(prompt_func)
+    
+    def _python_type(self, type_str: str) -> str:
+        """Convert YAML type to Python type annotation."""
+        type_mapping = {
+            "string": "str",
+            "number": "float",
+            "boolean": "bool",
+            "array": "List[str]"
+        }
+        return type_mapping.get(type_str, "str")
+    
+    def _python_value(self, value: Any, type_str: str) -> str:
+        """Convert value to Python literal string."""
+        if type_str == "string":
+            return repr(str(value))
+        elif type_str == "number":
+            return str(value)
+        elif type_str == "boolean":
+            return str(value)
+        elif type_str == "array":
+            return repr(value)
+        else:
+            return repr(str(value))
+    
+    def _create_tool_docstring(self, tool_name: str, tool, resolved_args: List) -> str:
+        """Create docstring for a tool function."""
+        doc_parts = [tool.desc]
+        
+        if resolved_args:
+            doc_parts.append("\nParameters:")
+            for arg in resolved_args:
+                doc_parts.append(f"- {arg.name} ({arg.type}): {arg.help}")
+                if arg.default is not None:
+                    doc_parts.append(f"  Default: {arg.default}")
+                if arg.choices:
+                    doc_parts.append(f"  Allowed values: {', '.join(map(str, arg.choices))}")
+                if arg.pattern:
+                    doc_parts.append(f"  Pattern: {arg.pattern}")
+        
+        doc_parts.append("\nReturns:")
+        doc_parts.append("    Dict[str, Any]: Command execution result with 'success', 'stdout', 'stderr', and 'returncode' fields.")
+        
+        return "\n".join(doc_parts)
+    
+    def _create_resource_docstring(self, resource_name: str, resource, resolved_args: List) -> str:
+        """Create docstring for a resource function."""
+        doc_parts = [resource.description or resource.name]
+        
+        if resolved_args:
+            doc_parts.append("\nParameters:")
+            for arg in resolved_args:
+                doc_parts.append(f"- {arg.name} ({arg.type}): {arg.help}")
+                if arg.default is not None:
+                    doc_parts.append(f"  Default: {arg.default}")
+                if arg.choices:
+                    doc_parts.append(f"  Allowed values: {', '.join(map(str, arg.choices))}")
+                if arg.pattern:
+                    doc_parts.append(f"  Pattern: {arg.pattern}")
+        
+        doc_parts.append("\nReturns:")
+        doc_parts.append("    str: The resource content.")
+        
+        return "\n".join(doc_parts)
+    
+    def _create_prompt_docstring(self, prompt_name: str, prompt, resolved_args: List) -> str:
+        """Create docstring for a prompt function."""
+        doc_parts = [prompt.description or prompt.name]
+        
+        if resolved_args:
+            doc_parts.append("\nParameters:")
+            for arg in resolved_args:
+                doc_parts.append(f"- {arg.name} ({arg.type}): {arg.help}")
+                if arg.default is not None:
+                    doc_parts.append(f"  Default: {arg.default}")
+                if arg.choices:
+                    doc_parts.append(f"  Allowed values: {', '.join(map(str, arg.choices))}")
+                if arg.pattern:
+                    doc_parts.append(f"  Pattern: {arg.pattern}")
+        
+        doc_parts.append("\nReturns:")
+        doc_parts.append("    str: The generated prompt content.")
+        
+        return "\n".join(doc_parts)
+    
+    def run(self):
+        """Run the MCP server."""
+        print(f"Starting {self.config.server.name} v{self.config.server.version}")
+        print(f"Description: {self.config.server.desc}")
+        self.mcp.run()
+
+
+def get_builtin_config(config_name: str) -> str:
+    """Get path to a built-in configuration file."""
+    config_dir = Path(__file__).parent / "configs"
+    config_file = config_dir / f"{config_name}.yml"
+    
+    if not config_file.exists():
+        available_configs = [f.stem for f in config_dir.glob("*.yml")]
+        raise ValueError(f"Built-in config '{config_name}' not found. Available configs: {', '.join(available_configs)}")
+    
+    return str(config_file)
+
+
+def run_config(config_file: str):
+    """Run an MCP server from a YAML configuration file."""
+    parser = YMLParser()
+    config = parser.load_from_file(config_file)
+    
+    runner = MCPRunner(config)
+    runner.run()


### PR DESCRIPTION
Add a `shellmcp run` command to start pre-configured or custom YAML-defined MCP servers directly, enabling quick setup for common shell operations.

---
<a href="https://cursor.com/background-agent?bcId=bc-5122bf19-d3e5-4c54-92fc-bfb8fc10bc29">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5122bf19-d3e5-4c54-92fc-bfb8fc10bc29">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

